### PR TITLE
fix: align .feature Feature line with CAMARA Testing Guidelines

### DIFF
--- a/code/Test_definitions/iot-sim-fraud-prevention-bind.feature
+++ b/code/Test_definitions/iot-sim-fraud-prevention-bind.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA IoT SIM Fraud Prevention API wip - Operation bindDeviceImei
+Feature: CAMARA IoT SIM Fraud Prevention API, vwip - Operation bindDeviceImei
 
     # Input to be provided by the implementation to the tester
     #

--- a/code/Test_definitions/iot-sim-fraud-prevention-query.feature
+++ b/code/Test_definitions/iot-sim-fraud-prevention-query.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA IoT SIM Fraud Prevention API wip - Operation query
+Feature: CAMARA IoT SIM Fraud Prevention API, vwip - Operation query
 
     # Input to be provided by the implementation to the tester
     #

--- a/code/Test_definitions/iot-sim-fraud-prevention-subscriptions-callback.feature
+++ b/code/Test_definitions/iot-sim-fraud-prevention-subscriptions-callback.feature
@@ -1,4 +1,4 @@
-Feature: IoT SIM Fraud Prevention Subscriptions - Callback Handling
+Feature: CAMARA IoT SIM Fraud Prevention Subscriptions, vwip - Callback Handling
 
     # This file tests the API consumer's callback endpoint.
     # It validates that the consumer correctly handles incoming notifications following CloudEvents specification.

--- a/code/Test_definitions/iot-sim-fraud-prevention-subscriptions-notifications.feature
+++ b/code/Test_definitions/iot-sim-fraud-prevention-subscriptions-notifications.feature
@@ -1,4 +1,4 @@
-Feature: IoT SIM Fraud Prevention Subscriptions - Notification Delivery
+Feature: CAMARA IoT SIM Fraud Prevention Subscriptions, vwip - Notification Delivery
 
   This feature tests the end‑to‑end delivery of notifications for the explicit subscriptions model.
   It assumes the existence of:

--- a/code/Test_definitions/iot-sim-fraud-prevention-subscriptions-subscribe.feature
+++ b/code/Test_definitions/iot-sim-fraud-prevention-subscriptions-subscribe.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA IoT SIM Fraud Prevention Subscriptions - Operation subscribeFraudPrevention
+Feature: CAMARA IoT SIM Fraud Prevention Subscriptions, vwip - Operation subscribeFraudPrevention
 
     # Input to be provided by the implementation to the tester
     #

--- a/code/Test_definitions/iot-sim-fraud-prevention-unbind.feature
+++ b/code/Test_definitions/iot-sim-fraud-prevention-unbind.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA IoT SIM Fraud Prevention API wip - Operation unbindDeviceImei
+Feature: CAMARA IoT SIM Fraud Prevention API, vwip - Operation unbindDeviceImei
 
     # Input to be provided by the implementation to the tester
     #


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Aligns the `Feature:` line in the six `.feature` files under
`code/Test_definitions/` with the CAMARA Testing Guidelines format
`Feature: CAMARA <API Name>, vwip - <Operation / Scenario>`:

- Three main-API files had `API wip -` → `API, vwip -`
- Three subscription files were missing the `, vwip` version marker (and
  two were missing the `CAMARA` prefix)

Detected via the validation framework's P-007 (check-test-file-version).

#### Which issue(s) this PR fixes:

_None — trivial format alignment._

#### Special notes for reviewers:

Only the first line of each file changes. No scenario or step content
touched.

#### Changelog input

```
 release-note
none
```

#### Additional documentation

```
docs
none
```